### PR TITLE
adding -All parameter

### DIFF
--- a/MFA_NPS_Troubleshooter.ps1
+++ b/MFA_NPS_Troubleshooter.ps1
@@ -268,7 +268,7 @@ write-host
 
 $AllSPNs = ''
 
-$AllSPNs = Get-MsolServicePrincipal | select AppPrincipalId 
+$AllSPNs = Get-MsolServicePrincipal -All | select AppPrincipalId 
 
 #if the MFA NPS is exist in $AllSPNs then it will check it's status if it's enabled or not, if it's not exist the test will faile directly
 


### PR DESCRIPTION
Adding the `-All` parameter allows for test 5 to succeed when max results are exceeded for the AAD tenant. This should address #2 .