### PR TITLE
Adding All to retrieve all ServicePrincipals

### DIFF
--- a/MFA_NPS_Troubleshooter.ps1
+++ b/MFA_NPS_Troubleshooter.ps1
@@ -268,7 +268,7 @@ write-host
 
 $AllSPNs = ''
 
-$AllSPNs = Get-MsolServicePrincipal | select AppPrincipalId 
+$AllSPNs = Get-MsolServicePrincipal -All | select AppPrincipalId
 
 #if the MFA NPS is exist in $AllSPNs then it will check it's status if it's enabled or not, if it's not exist the test will faile directly
 


### PR DESCRIPTION
If you do not add All, chances are that the ServicePrincipal for MFA will not be returned.