### PR TITLE
Evaluate if C:\NPS folder has been created or not

### DIFF
--- a/MFA_NPS_Troubleshooter.ps1
+++ b/MFA_NPS_Troubleshooter.ps1
@@ -1024,8 +1024,21 @@ $ErrorActionPreference= 'silentlycontinue'
 #start collecting logs
 Set-Itemproperty -path 'HKLM:\SOFTWARE\Microsoft\AzureMfa' -Name 'VERBOSE_LOG' -value 'True'
 
-mkdir c:\NPS
-cd C:\NPS
+$DirectoryToCreate = "C:\NPS"
+if (-not (Test-Path -LiteralPath $DirectoryToCreate)) {
+    
+    try {
+        New-Item -Path $DirectoryToCreate -ItemType Directory -ErrorAction Stop | Out-Null #-Force
+    }
+    catch {
+        Write-Error -Message "Unable to create directory '$DirectoryToCreate'. Error was: $_" -ErrorAction Stop
+    }
+    "Successfully created directory '$DirectoryToCreate'."
+
+}
+else {
+    "Directory already existed"
+}
 Remove-Item "c:\nps\*.txt", "c:\nps\*.evtx", "c:\nps\*.etl","c:\nps\*.log", "c:\nps\*.cab"
 
 netsh trace start capture=yes overwrite=yes  tracefile=C:\NPS\nettrace.etl
@@ -1092,6 +1105,22 @@ $AuthorizationDLLs_Backup = (Get-ItemProperty -Path Registry::HKEY_LOCAL_MACHINE
 $ExtensionDLLs_Backup = (Get-ItemProperty -Path Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\AuthSrv\Parameters -Name ExtensionDLLs).ExtensionDLLs
 
 Write-Host -ForegroundColor Yellow "Exporting the NPS MFA registry keys."
+$DirectoryToCreate = "C:\NPS"
+if (-not (Test-Path -LiteralPath $DirectoryToCreate)) {
+    
+    try {
+        New-Item -Path $DirectoryToCreate -ItemType Directory -ErrorAction Stop | Out-Null #-Force
+    }
+    catch {
+        Write-Error -Message "Unable to create directory '$DirectoryToCreate'. Error was: $_" -ErrorAction Stop
+    }
+    "Successfully created directory '$DirectoryToCreate'."
+
+}
+else {
+    "Directory already existed"
+}
+Remove-Item "c:\nps\*.txt", "c:\nps\*.evtx", "c:\nps\*.etl","c:\nps\*.log", "c:\nps\*.cab"
 reg export hklm\system\currentcontrolset\services\authsrv c:\nps\AuthSrv.reg /y 
 
 Set-ItemProperty -Path Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\AuthSrv\Parameters -Name AuthorizationDLLs -Value ''

--- a/MFA_NPS_Troubleshooter.ps1
+++ b/MFA_NPS_Troubleshooter.ps1
@@ -386,7 +386,7 @@ $CLIENT_ID = (Get-ItemProperty -path HKLM:\SOFTWARE\Microsoft\AzureMfa -name "CL
 
 $STS_URL = (Get-ItemProperty -path HKLM:\SOFTWARE\Microsoft\AzureMfa -name "STS_URL").STS_URL
 
-if ($AZURE_MFA_HOSTNAME -eq "adnotifications.windowsazure.com" -and $AZURE_MFA_TARGET_PATH -eq "StrongAuthenticationService.svc/Connector" -and $CLIENT_ID -eq "981f26a1-7f43-403b-a875-f8b09b8cd720" -and $STS_URL -eq "https://login.microsoftonline.com/")
+if ($AZURE_MFA_HOSTNAME -eq "strongauthenticationservice.auth.microsoft.com" -and $AZURE_MFA_TARGET_PATH -eq "StrongAuthenticationService.svc/Connector" -and $CLIENT_ID -eq "981f26a1-7f43-403b-a875-f8b09b8cd720" -and $STS_URL -eq "https://login.microsoftonline.com/")
 
 {
 


### PR DESCRIPTION
When running script on 1st time, noticed an error message because folder c:\nps was not present. So, it's great to evaluate if it's already created or not and fill with the required info. Added to both functions MFAorNPS and Collect_logs